### PR TITLE
Update admin permissions on initialization

### DIFF
--- a/initialization/sql.go
+++ b/initialization/sql.go
@@ -36,10 +36,16 @@ func InitUserRolesSQL(ctx *ctx.Context) {
 	}
 
 	err := db.Where("name = ?", "admin").First(&adminRole).Error
-	if err == gorm.ErrRecordNotFound {
-		err := ctx.DB.DB().Create(&roles).Error
-		if err != nil {
-			global.Logger.Sugar().Errorf(err.Error())
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			err = ctx.DB.DB().Create(&roles).Error
 		}
+	} else {
+		err = db.Where("name = ?", "admin").Updates(models.UserRole{Permissions: perms}).Error
+	}
+
+	if err != nil {
+		global.Logger.Sugar().Errorf(err.Error())
+		panic(err)
 	}
 }


### PR DESCRIPTION
## 问题

当使用 deploy/sql 下的 user_roles.sql 执行了用户角色初始化后，由于后续路由的更新，导致部分接口会提示无权限调用。

## 处理

参考了Permissions表的初始化逻辑，在程序启动时主动对 admin 角色权限信息进行更新。这样可以省去频繁更新 user_roles.sql 脚本的权限数据。

如有不妥或者和设计思路不符，请指正。
